### PR TITLE
🔧 (devenv) Ignore `INP001` rule in Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ ignore = [
   "D104",   # undocumented-public-package
   "E501",   # line-too-long
   "F401",   # unused-import
+  "INP001", # implicit-namespace-package
   "T201",   # print
 ]
 pydocstyle.convention = "google"


### PR DESCRIPTION
### 🔍 Overview

Added `INP001` rule to the ignore list in the Ruff configuration.

### 🔗 Linked issue

#18

### 📌 Additional comments

None
